### PR TITLE
snmp-ups.c : fix loading of DMF into mib2nut

### DIFF
--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -68,6 +68,9 @@
 #endif
 
 #ifdef WITH_DMFMIB
+// Array of pointers to singular instances of mib2nut_info_t
+// NOTE: Not the dmp->mib2nut_table itself, but array of 
+// addresses of each of its entries
 mib2nut_info_t **mib2nut = NULL;
 mibdmf_parser_t *dmp = NULL;
 #else
@@ -316,13 +319,52 @@ void upsdrv_initups(void)
 		mibdmf_parse_dir("./", dmp);
 #endif
 	upsdebugx(2,"Trying to access the mib2nut table parsed from DMF library");
-	mib2nut = mibdmf_get_mib2nut_table_ptr(dmp);
-	if (!mib2nut)
+	if ( !(mibdmf_get_mib2nut_table(dmp)) )
 	{
 		upsdebugx(1,"FATAL: Can not access the mib2nut table parsed from DMF library");
 		return;
 	}
-	upsdebugx(2,"Got access to the mib2nut table parsed from DMF library");
+        { // scope the table loop vars
+                // TODO: Change size detection to loop over array until NULLed sentinels?
+                int tablength = mibdmf_get_device_table_counter(dmp), i;
+                mib2nut_info_t* mib2nut_table = NULL;
+                upsdebugx(2,"Got access to the mib2nut table with %d entries parsed from DMF library",
+                        tablength);
+                if (tablength<=1) {
+                        upsdebugx(1,"FATAL: Did not find any DMF library data");
+                        return;
+                }
+                if ( !mib2nut ) {
+                        upsdebugx(1,"mib2nut not NULL when expected to be...");
+                        free(mib2nut);
+                }
+                mib2nut = (mib2nut_info_t**) calloc(tablength, sizeof (mib2nut_info_t*));
+                if ( !mib2nut ) {
+        		upsdebugx(1,"FATAL: Could not allocate mib2nut index table");
+                	return;
+                }
+                mib2nut_table = *(mibdmf_get_mib2nut_table_ptr(dmp));
+                for (i=0;  mib2nut_table[i].mib_name != NULL
+                        || mib2nut_table[i].mib_version != NULL
+                        || mib2nut_table[i].oid_pwr_status != NULL
+                        || mib2nut_table[i].oid_auto_check != NULL
+                        || mib2nut_table[i].sysOID != NULL
+                        || mib2nut_table[i].snmp_info != NULL
+                        || mib2nut_table[i].alarms_info != NULL
+#ifdef WITH_DMF_LUA
+                        || mib2nut_table[i].functions != NULL
+#endif
+                        ; i++ )
+                {
+                        if (i>=tablength) {
+                		upsdebugx(1,"FATAL: Seems we have more mib2nut entries in practice than allocated by counter (i==%d)", i);
+                        	return;
+                        }
+                        mib2nut[i] = &mib2nut_table[i];
+                }
+                // The last i'th entry is the sentinel, but we don't link to it
+                mib2nut[i] = NULL;
+        } // scope the table loop vars
 #endif
 
 	/* Retrieve user's parameters */


### PR DESCRIPTION
From debug log of startup:

```
$ egrep -v '^#|^$' /etc/nut/ups.conf
maxretry = 3
[nutdev1]
        driver = snmp-ups
        port = 10.130.53.33
[nutdev1d]
        driver = snmp-ups-dmf
        port = 10.130.53.33


jim@debian8:~/nut-DMF-linux/drivers$ sudo `pwd`/snmp-ups-dmf -DDDDD -a nutdev1d
Network UPS Tools - Generic SNMP UPS driver (DMF) 0.98 (2.7.4-301-g76ce01c)
   0.000000 send_to_all: SETINFO driver.parameter.port "10.130.53.33"
   0.001243 debug level is '5'
   0.002041 SNMP UPS driver: entering upsdrv_initups()
   0.010029 Trying to access the mib2nut table parsed from DMF library
   0.010507 Got access to the mib2nut table with 24 entries parsed from DMF library
   0.011111 mib2nut not NULL when expected to be...
   0.012446 SNMP UPS driver: entering nut_snmp_init(snmp-ups-dmf)
   0.015176 Setting SNMP retries to 5
   0.015669 Setting SNMP timeout to 1 second(s)
   0.016213 SNMP UPS driver: entering load_mib2nut(auto)
   0.016835 trying the new match_sysoid() method
   0.017167 Entering nut_snmp_get_oid()
   0.017348 nut_snmp_get(.1.3.6.1.2.1.1.2.0)
   0.017469 nut_snmp_walk(.1.3.6.1.2.1.1.2.0)
   0.018203 nut_snmp_walk: max. iteration = 1
   0.116699 OID value: .1.3.6.1.4.1.705.1
   0.117322 match_sysoid: device sysOID value = .1.3.6.1.4.1.705.1
   0.117743 match_sysoid: checking MIB bestpower
   0.118008 match_sysoid: checking MIB apcc
   0.118134 match_sysoid: checking MIB raritan
   0.118257 match_sysoid: comparing .1.3.6.1.4.1.705.1 with .1.3.6.1.4.1.13742
   0.118377 match_sysoid: checking MIB eaton_ats
   0.118504 match_sysoid: comparing .1.3.6.1.4.1.705.1 with .1.3.6.1.4.1.705.1
...
   4.474008 SU_CMD_MASK => 1.3.6.1.2.1.33.1.8.3.0
   4.474068 send_to_all: SETINFO ups.status "OL OL"
   4.474234 dstate_init: sock /var/state/ups/snmp-ups-dmf-nutdev1d open on fd 5
   4.474305 send_to_all: SETINFO driver.parameter.pollinterval "2"
   4.474399 send_to_all: SETINFO driver.parameter.synchronous "no"
   4.474443 send_to_all: SETINFO device.mfr "Eaton"
   4.474486 send_to_all: SETINFO device.model "Eaton 9PX"
   4.474528 send_to_all: SETINFO device.serial "G202D51129"
   4.474569 SNMP UPS driver: entering upsdrv_updateinfo()
   6.477210 SNMP UPS driver: entering upsdrv_updateinfo()
```

I am not sure if we need to look deeper at alarms_info, mib2nut_info and snmp_info - but at least now the driver does not crash and runs the loop well (re-fetches data every 30 sec from actual device).
