### PR TITLE
DMF integrated with libnutscan and the nut-scanner tool

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -29,6 +29,7 @@ if WITH_SNMP
   libnutdmfsnmp_la_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/drivers \
         -I$(top_srcdir)/tools/nut-scanner \
         $(LIBNETSNMP_CFLAGS) $(LIBNEON_CFLAGS)
-  libnutdmfsnmp_la_LIBADD = $(LIBNETSNMP_LIBS) $(LIBNEON_LIBS) libcommon.la
+# Note: Conumers of this lib will generally want these linked in:
+#  libnutdmfsnmp_consumer_LDADD = $(LIBNETSNMP_LIBS) $(LIBNEON_LIBS) libcommon.la
 endif
 endif

--- a/docs/nut-dmf.txt
+++ b/docs/nut-dmf.txt
@@ -31,6 +31,9 @@ DMF markup to `stdout` so you can redirect it to another file. To avoid later
 duplicate entries, consider naming that file with a different extension (may
 be uppercased `*.DMF` for example) or save it into a different directory.
 
+NOTE: If you provide your own DMF files that are not generated from existing
+`*-mib.c` sources, use some filename pattern that does not end in `-mib.dmf`!
+
 Overview of DMF usage from C code is maintained in the `dmf.h` file, driver
 and application developers should look there for the "The big theory" details.
 It is expected that DMF will outgrow the initial SNMP use-case, so there is

--- a/docs/nut-dmf.txt
+++ b/docs/nut-dmf.txt
@@ -55,6 +55,14 @@ Verifiable schemas are provided as XSD files and can be run against existing
 or generated DMF files with `make dmf-validate` in the `scripts/DMF` directory
 (uses `xmllint` which is also needed to build NUT manpages with `asciidoc`).
 
+The command-line method of verification that a DMF SNMP file or an index file
+built for the `nut-scanner` conforms to expected schema is:
+
+----
+    $ xmllint --noout --schema $SCHEMADIR/dmfsnmp.xsd $TESTEDFILE.dmf
+    $ xmllint --noout --schema $SCHEMADIR/dmfnutscan.xsd $TESTEDINDEX.dmf
+----
+
 There are *4* main structures in the DMF XML:
 
  * `info_lkp_t`: mapping between NUT and SNMP values for a variable
@@ -121,7 +129,8 @@ Details on some of the tools are presented below.
 === Python and pycparser prerequisites
 
 You need Python version 2.7 with an `argparse` module, as well as a separate
-`pycparser` installed to run it:
+project `pycparser` installed on the build host to run the `jsonify-mib.py`
+script:
 
  * via your package management
    As an example, you can do so:

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -212,7 +212,7 @@ snmp_ups_CFLAGS = $(AM_CFLAGS) -UWITH_DMFMIB
 
 snmp_ups_dmf_SOURCES = snmp-ups.c
 snmp_ups_dmf_LDADD = $(LDADD_DRIVERS) $(LIBNETSNMP_LIBS) $(LIBNEON_LIBS) \
- ../common/libnutdmfsnmp.la ../common/libcommon.la
+ $(top_builddir)/common/libnutdmfsnmp.la $(top_builddir)/common/libcommon.la
 snmp_ups_dmf_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/tools/nut-scanner -DWITH_DMFMIB=1
 
 if WITH_SSL

--- a/scripts/DMF/Makefile.am
+++ b/scripts/DMF/Makefile.am
@@ -8,6 +8,13 @@ CC = gcc
 CPP = gcc
 CXX = g++
 
+# Note: this is automake "if"
+if HAVE_XMLLINT
+XMLLINT = @XMLLINT@
+else
+XMLLINT = xmllint
+endif
+
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
 
@@ -57,6 +64,7 @@ clean-local:
 
 check: check-local
 
+# Note: this is automake "if"
 if HAVE_XMLLINT
   check-local: progs run-dmf-test dmf-validate
 else
@@ -132,7 +140,7 @@ $(DMFSNMP_SUBDIR)/.validated: $(builddir)/$(DMFSNMP_SUBDIR)/.validated
 $(builddir)/$(DMFSNMP_SUBDIR)/.validated: $(builddir)/$(DMFSNMP_SUBDIR)/.uptodate
 	@cd $(@D) && for F in *.dmf ; do \
 	    echo " XMLLINT  $$F"; \
-	    xmllint --noout --schema $(abs_srcdir)/dmfsnmp.xsd "$$F" || exit; \
+	    $(XMLLINT) --noout --schema $(abs_srcdir)/dmfsnmp.xsd "$$F" || exit; \
 	done
 
 # TODO: Maybe per-DMF *.dmf.validated files would be better?
@@ -140,7 +148,7 @@ $(DMFNUTSCAN_SUBDIR)/.validated: $(builddir)/$(DMFNUTSCAN_SUBDIR)/.validated
 $(builddir)/$(DMFNUTSCAN_SUBDIR)/.validated: $(builddir)/$(DMFNUTSCAN_SUBDIR)/.uptodate
 	@ERRCODE=0; cd $(@D) && for F in *.dmf ; do \
 	    echo " XMLLINT  $$F"; \
-	    xmllint --noout --schema $(abs_srcdir)/dmfnutscan.xsd "$$F" || ERRCODE=1; \
+	    $(XMLLINT) --noout --schema $(abs_srcdir)/dmfnutscan.xsd "$$F" || ERRCODE=1; \
 	done; exit $$ERRCODE
 
 # Make sure all generated DMFs are up to date vs. C sources and recipes
@@ -149,6 +157,7 @@ dmf-uptodate: $(DMFSNMP_SUBDIR)/.uptodate $(DMFNUTSCAN_SUBDIR)/.uptodate
 # Make sure all present DMFs are valid vs. XSD schema
 dmf-validate: dmf-uptodate $(DMFSNMP_SUBDIR)/.validated $(DMFNUTSCAN_SUBDIR)/.validated
 
+# Note: this is automake "if"
 if HAVE_XMLLINT
   dmf: dmf-validate
 else

--- a/scripts/DMF/Makefile.am
+++ b/scripts/DMF/Makefile.am
@@ -39,6 +39,8 @@ DMFSNMP_SUBDIR = dmfsnmp
 DMFNUTSCAN_SUBDIR = dmfnutscan
 
 # Automake installation
+# NOTE: If you provide your own DMF files that are not generated from "*-mib.c"
+# existing sources, use some filename pattern that does not end in "-mib.dmf"!
 dmfsnmpdir = @dmfsnmpdir@
 dmfsnmp_DATA = $(wildcard $(DMFSNMP_SUBDIR)/*.dmf) dmfsnmp.xsd
 

--- a/tools/nut-scanner/Makefile.am
+++ b/tools/nut-scanner/Makefile.am
@@ -40,6 +40,18 @@ nut_scanner_SOURCES = nut-scanner.c
 nut_scanner_CFLAGS = -I$(top_srcdir)/clients -I$(top_srcdir)/include
 nut_scanner_LDADD = libnutscan.la
 
+if WITH_SNMP
+if WITH_NEON
+nut_scanner_CFLAGS += -DWITH_DMFMIB=1 -I$(top_srcdir)/drivers
+libnutscan_la_LIBADD += $(top_builddir)/common/libnutdmfsnmp.la
+#	$(top_builddir)/common/libcommon.la $(top_builddir)/common/libparseconf.la
+# The libs needed to handle XML parsing and usage of DMF SNMP are ltdl()'ed
+# but without this builds fail (TODO: Revise responsible code? LTDL in DMF?)
+#	$(LIBNETSNMP_LIBS)
+libnutscan_la_LIBADD += $(LIBNEON_LIBS)
+endif
+endif
+
 if WITH_SSL
   libnutscan_la_CFLAGS += $(LIBSSL_CFLAGS)
   libnutscan_la_LIBADD += $(LIBSSL_LIBS)

--- a/tools/nut-scanner/README
+++ b/tools/nut-scanner/README
@@ -9,7 +9,11 @@ linkman:nut-scanner[8] is available to discover supported NUT devices
 classic connection method).
 
 This tool actually uses a library, called *libnutscan*, to perform actual
-processing.
+processing. The library is built with DMF support for SNMP device discovery,
+when it can use loadable files that map MIB and other needed details to NUT
+internals. If the client does not set relevant flags for loading DMF, or if
+no data was successfully loaded, the library would fall back to using the
+legacy static built-in structure with some mappings available in it.
 
 
 Client access library

--- a/tools/nut-scanner/nutscan-snmp.h
+++ b/tools/nut-scanner/nutscan-snmp.h
@@ -33,7 +33,11 @@ typedef struct {
 #endif /* DEVSCAN_SNMP_H */
 
 /* SNMP IDs device table, excerpt generated from our available MIBs */
-/* Note: This is commented away with ifdefs, so the consumers who only need
+/* The consumer defines an instance of this table, either dynamic with DMF
+ * or a precompiled legacy binary based on ifdef WITH_DMFMIB compile-time
+ * support and real-time DMF availability (as fallback for no/bad/empty DMF),
+ * with explicit reference like below (builtin generated into nutscan-snmp.c).
+ * Note: This is commented away with ifdefs, so the consumers who only need
  * the structure definition are not burdened with an external reference to
  * structure instances they would not need.
  */
@@ -45,3 +49,10 @@ typedef struct {
     extern snmp_device_id_t *snmp_device_table_builtin;
 # endif /* DEVSCAN_SNMP_BUILTIN */
 #endif /* WANT_DEVSCAN_SNMP_BUILTIN */
+#if WANT_DEVSCAN_SNMP_DMF == 1
+# ifndef DEVSCAN_SNMP_DMF
+#  define DEVSCAN_SNMP_DMF
+/* Can use a copy of the structure that will be populated dynamically */
+    extern snmp_device_id_t *snmp_device_table_dmf;
+# endif /* DEVSCAN_SNMP_DMF */
+#endif /* WANT_DEVSCAN_SNMP_DMF */


### PR DESCRIPTION
Now libnutscan is built with DMF support (practically unconditionally at the moment, so requires linking with LIBNEON in particular). The nut-scanner client to the library can enable or disable usage of DMF vs. built-in old structure on the fly (using new `-z` or `-Z dirname` options). If an SNMP-enabled device is recognized while using DMF, the "snmp-ups-dmf" driver is suggested in the produced `ups.conf` snippet. Verified to work with default (-z) and custom (-Z) DMF directories and with fallback to built-in tables, single and multiple SNMP devices.

Also fixes the bug that with earlier code-drop `nut-scanner` segfaulted - not anymore.

`make distcheck` still passes ;)

NOTE: Verified that parse_dir() allows to load data from symlinks to DMF files, so at least having a custom directory option (-Z dir) allows an end-user to symlink resources he wants to be available for a scan into a temporary directory (reasonable workaround to not having more flexible options)...
