### PR TITLE
drivers/Makefile.am fix build fail with as needed linker flags

### DIFF
--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -211,8 +211,9 @@ snmp_ups_LDADD = $(LDADD_DRIVERS) $(LIBNETSNMP_LIBS)
 snmp_ups_CFLAGS = $(AM_CFLAGS) -UWITH_DMFMIB
 
 snmp_ups_dmf_SOURCES = snmp-ups.c
-snmp_ups_dmf_LDADD = $(LDADD_DRIVERS) $(LIBNETSNMP_LIBS) $(LIBNEON_LIBS) \
- $(top_builddir)/common/libnutdmfsnmp.la $(top_builddir)/common/libcommon.la
+snmp_ups_dmf_LDADD = $(LDADD_DRIVERS) $(LIBNETSNMP_LIBS) \
+ $(top_builddir)/common/libnutdmfsnmp.la $(LIBNEON_LIBS) \
+ $(top_builddir)/common/libcommon.la
 snmp_ups_dmf_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/tools/nut-scanner -DWITH_DMFMIB=1
 
 if WITH_SSL


### PR DESCRIPTION
The neon libs must be placed _after_ the libnutdmfsnmp.la during the
linking
