### PR TITLE
DMF design bugfix: before was all drivers fields in the same list and this causes proble…

### DIFF
--- a/common/dmfsnmp.c
+++ b/common/dmfsnmp.c
@@ -1003,7 +1003,7 @@ compile_flags(const char **attrs)
         if(aux_flags)free(aux_flags);
 #ifdef WITH_DMF_LUA
         aux_flags = get_param_by_name(TYPE_FUNCTION, attrs);
-        if(aux_flags)if(strcmp(aux_flags, YES) == 0){
+        if(aux_flags){
                         flags = flags | SU_FLAG_FUNCTION;
                 }
         if(aux_flags)free(aux_flags);

--- a/common/dmfsnmp.c
+++ b/common/dmfsnmp.c
@@ -505,14 +505,14 @@ alist_t *
 mibdmf_get_aux_list(mibdmf_parser_t *dmp)
 {
 	if (dmp==NULL) return NULL;
-	return dmp->list;
+	return dmp->list[dmp->sublist_elements - 1];
 }
 
 alist_t **
 mibdmf_get_aux_list_ptr(mibdmf_parser_t *dmp)
 {
 	if (dmp==NULL) return NULL;
-	return &(dmp->list);
+	return &(dmp->list[dmp->sublist_elements - 1]);
 }
 
 // Properly destroy the object hierarchy and NULLify the caller's pointer
@@ -521,6 +521,7 @@ mibdmf_parser_destroy(mibdmf_parser_t **self_p)
 {
 	if (*self_p)
 	{
+                int i;
 		mibdmf_parser_t *self = (mibdmf_parser_t *) *self_p;
 		// First we destroy the index tables that reference data in the list...
 		if (self->device_table)
@@ -533,15 +534,37 @@ mibdmf_parser_destroy(mibdmf_parser_t **self_p)
 			free(self->mib2nut_table);
 			self->mib2nut_table = NULL;
 		}
-		if (self->list)
+		for(i = 0; i < self->sublist_elements; i++)
 		{
-			alist_destroy( &(self->list) );
-			self->list = NULL;
+                     if(self->list[i])
+			alist_destroy( &(self->list[i]) );
+			self->list[i] = NULL;
 		}
+		free(self->list);
 		self->device_table_counter = 0;
 		free (self);
 		*self_p = NULL;
 	}
+}
+
+/*This function is implemented for isolate every XML driver.
+ * before was all drivers fields in the same list and this causes problems when
+ * two elements from difrent driver have the same name, now all drivers are isolete in their
+ * own alist, then is possible to have the same names without making bugs
+ * If it necessary, the design allows in the future implement a function for share elements with drivers.
+ * but no anymore by accident.*/
+void
+mibdmf_parser_new_list(mibdmf_parser_t *dmp)
+{
+  dmp->sublist_elements++;
+  if(dmp->sublist_elements == 1)
+    dmp->list = (alist_t **) malloc((dmp->sublist_elements + 1) * sizeof(alist_t *));
+  else
+    dmp->list = (alist_t **) realloc(dmp->list, (dmp->sublist_elements + 1) * sizeof(alist_t *));
+  assert (dmp->list);
+  dmp->list[dmp->sublist_elements - 1] = alist_new( NULL,(void (*)(void **))alist_destroy, NULL );
+  assert (dmp->list[dmp->sublist_elements - 1]);
+  dmp->list[dmp->sublist_elements] = NULL;
 }
 
 mibdmf_parser_t *
@@ -558,8 +581,7 @@ mibdmf_parser_new()
 	assert (self->device_table);
 	assert (self->mib2nut_table);
 	assert (self->device_table_counter >= 1);
-	self->list = alist_new( NULL,(void (*)(void **))alist_destroy, NULL );
-	assert (self->list);
+        self->sublist_elements = 0;
 	return self;
 }
 
@@ -1180,6 +1202,7 @@ mibdmf_parse_file(char *file_name, mibdmf_parser_t *dmp)
 
 	assert (file_name);
 	assert (dmp);
+        mibdmf_parser_new_list(dmp);
 	assert (mibdmf_get_aux_list(dmp)!=NULL);
 
 	if ( (file_name == NULL ) || \
@@ -1256,6 +1279,7 @@ mibdmf_parse_str (const char *dmf_string, mibdmf_parser_t *dmp)
 
 	assert (dmf_string);
 	assert (dmp);
+        mibdmf_parser_new_list(dmp);
 	assert (mibdmf_get_aux_list(dmp)!=NULL);
 
 	if ( (dmf_string == NULL ) || \

--- a/include/dmfsnmp.h
+++ b/include/dmfsnmp.h
@@ -224,7 +224,8 @@ typedef enum {
 /* Aggregate the data storage and variables needed to
  * parse the DMF representation of MIB data for NUT */
 typedef struct {
-	alist_t *list;
+	alist_t **list;
+        int sublist_elements;
 	snmp_device_id_t *device_table;
 	mib2nut_info_t **mib2nut_table;
 
@@ -321,6 +322,8 @@ alist_t **
 int *
 	mibdmf_get_device_table_counter_ptr(mibdmf_parser_t *dmp);
 
+void
+mibdmf_parser_new_list(mibdmf_parser_t *dmp);
 
 
 // Create and initialize info_lkp_t, a lookup element

--- a/scripts/DMF/dmf-test.c
+++ b/scripts/DMF/dmf-test.c
@@ -39,7 +39,7 @@
 #undef PACKAGE_STRING
 #undef PACKAGE_TARNAME
 #undef PACKAGE_BUGREPORT
-#include "mge-mib.c"
+#include "eaton-mib.c"
 
 int
 main ()
@@ -67,12 +67,12 @@ main ()
 	//mib2nut_info_t *m2n = get_mib2nut_table();
 	//print_mib2nut_memory_struct(m2n + 6);
 	//print_mib2nut_memory_struct(&pxgx_ups);
-	printf("=== DMF-Test: Loaded C structures (sample for 'mge'):\n\n");
+	printf("=== DMF-Test: Loaded C structures (sample for 'eaton_epdu'):\n\n");
 	print_mib2nut_memory_struct((mib2nut_info_t *)
-		alist_get_element_by_name(mibdmf_get_aux_list(dmp), "mge")->values[0]);
+		alist_get_element_by_name(mibdmf_get_aux_list(dmp), "eaton_marlin")->values[0]);
 	printf("\n\n");
-	printf("=== DMF-Test: Original C structures (sample for 'mge'):\n\n");
-	print_mib2nut_memory_struct(&mge);
+	printf("=== DMF-Test: Original C structures (sample for 'eaton_epdu'):\n\n");
+	print_mib2nut_memory_struct(&eaton_marlin);
 	//End debugging
 
 	printf("=== DMF-Test: Freeing data...\n\n");


### PR DESCRIPTION
…ms when

 two elements from difrent driver have the same name, now all drivers are isolete in their
 own alist, then is possible to have the same names without making bugs
 If it necessary, the design allows in the future implement a function for share elements with drivers.
 but no anymore by accident.
